### PR TITLE
add options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+dynamodb_create_cloudwatch_alarms.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 dynamodb_create_cloudwatch_alarms.egg-info
+exec.sh

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Options:
 
 ```
 
-# Install
+# Install and Usage
 ```bash
 $ git clone git@github.com:kentokento/dynamodb-create-cloudwatch-alarms.git
 $ cd ./dynamodb-create-cloudwatch-alarms

--- a/README.md
+++ b/README.md
@@ -15,18 +15,21 @@ If set as a cron job - updates existing alarms if
 Read/Write Capacity Units DynamoDB table parameters changed.
 
 Usage:
-    dynamodb_create_cloudwatch_alarms [options]
-    dynamodb_create_cloudwatch_alarms [-h | --help]
+    dynamodb-create-cloudwatch-alarms (-s <sns_topic_arn>) [-r <region>] [-p <prefix>] [--debug] 
+    dynamodb-create-cloudwatch-alarms [-h | --help]
 
 Options:
-    --debug   Don't send data to AWS
-    
-Examples:
-    dynamodb_create_cloudwatch_alarms
-    dynamodb_create_cloudwatch_alarms --debug
+     -s <sns_topic_arn>    For sending alarm ( require )
+     -r <region>           AWS region
+     -p <prefix>           DynamoDB name prefix
+     --debug               Don't send data to AWS
+
 ```
 
 # Install
 ```bash
-$ pip install dynamodb_create_cloudwatch_alarms
+$ git clone git@github.com:kentokento/dynamodb-create-cloudwatch-alarms.git
+$ cd ./dynamodb-create-cloudwatch-alarms
+$ make develop
+$ dynamodb-create-cloudwatch-alarms -s arn:aws:sns:ap-northeast-1:xxxxxxxxxx:hoge
 ```

--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@ Options:
 
 ```
 
-# Install and Usage
+# Install
 ```bash
-$ git clone git@github.com:kentokento/dynamodb-create-cloudwatch-alarms.git
-$ cd ./dynamodb-create-cloudwatch-alarms
-$ make develop
-$ dynamodb-create-cloudwatch-alarms -s arn:aws:sns:ap-northeast-1:xxxxxxxxxx:hoge
+$ pip install dynamodb_create_cloudwatch_alarms
 ```

--- a/dynamodb_create_cloudwatch_alarms/main.py
+++ b/dynamodb_create_cloudwatch_alarms/main.py
@@ -35,19 +35,39 @@ ALARM_PERIOD = 300
 ALARM_EVALUATION_PERIOD = 6
 RATE = 0.8
 
-
-def get_ddb_tables():
+def _get_ddb_tables_list(ddb_connection):
     """
     Retrieves all DynamoDB table names
 
     Returns:
         (set) Of valid DynamoDB table names
     """
-    ddb_connection = boto.dynamodb2.connect_to_region(AWS_REGION)
+
+    ddb_tables_list_all = []
+
     ddb_tables_list = ddb_connection.list_tables()
+    while ddb_tables_list.has_key(u'LastEvaluatedTableName'):
+        ddb_tables_list_all.extend(ddb_tables_list[u'TableNames'])
+        ddb_tables_list = ddb_connection.list_tables(exclusive_start_table_name=ddb_tables_list[u'LastEvaluatedTableName'])
+    else:
+        ddb_tables_list_all.extend(ddb_tables_list[u'TableNames'])
+
+    return ddb_tables_list_all
+
+
+def get_ddb_tables():
+    """
+    Retrieves all DynamoDB table describe
+
+    Returns:
+        (set) Of valid DynamoDB table describe list
+    """
+
+    ddb_connection = boto.dynamodb2.connect_to_region(AWS_REGION)
+    ddb_tables_list = _get_ddb_tables_list(ddb_connection)
 
     ddb_tables = set()
-    for ddb_table in ddb_tables_list['TableNames']:
+    for ddb_table in ddb_tables_list:
 
         if DYNAMO_PREF and not ddb_table.startswith(DYNAMO_PREF):
             continue

--- a/dynamodb_create_cloudwatch_alarms/main.py
+++ b/dynamodb_create_cloudwatch_alarms/main.py
@@ -169,7 +169,7 @@ def get_ddb_alarms_to_create(ddb_tables, aws_cw_connect):
             # update them if there are changes
             for key, value in existing_alarms.iteritems():
                 if (key == ddb_table_alarm.name
-                        and value != ddb_table_alarm.threshold):
+                        and str(value) != str(ddb_table_alarm.threshold)):
                     alarms_to_update.add(ddb_table_alarm)
 
     return (alarms_to_create, alarms_to_update)

--- a/dynamodb_create_cloudwatch_alarms/main.py
+++ b/dynamodb_create_cloudwatch_alarms/main.py
@@ -126,8 +126,9 @@ def get_existing_alarm_names(aws_cw_connect):
 
     for existing_alarm in existing_alarms:
         if existing_alarm.namespace == u'AWS/DynamoDB':
-            existing_alarm_names.update({existing_alarm.name:
-                                         existing_alarm.threshold})
+            existing_alarm_names.update({existing_alarm.name: {
+                                         u'threshold': existing_alarm.threshold,
+                                         u'alarm_actions': existing_alarm.alarm_actions}})
 
     return existing_alarm_names
 
@@ -189,7 +190,8 @@ def get_ddb_alarms_to_create(ddb_tables, aws_cw_connect):
             # update them if there are changes
             for key, value in existing_alarms.iteritems():
                 if (key == ddb_table_alarm.name
-                        and str(value) != str(ddb_table_alarm.threshold)):
+                        and (str(value[u'threshold']) != str(ddb_table_alarm.threshold)
+                        or value[u'alarm_actions'] != ddb_table_alarm.alarm_actions)):
                     alarms_to_update.add(ddb_table_alarm)
 
     return (alarms_to_create, alarms_to_update)


### PR DESCRIPTION
```
Usage:
    dynamodb-create-cloudwatch-alarms (-s <sns_topic_arn>) [-r <region>] [-p <prefix>] [--debug] 
    dynamodb-create-cloudwatch-alarms [-h | --help]

Options:
     -s <sns_topic_arn>    For sending alarm ( require )
     -r <region>           AWS region
     -p <prefix>           DynamoDB name prefix
     --debug               Don't send data to AWS
```
