### PR TITLE
average and threshold for dynamodb-create-cloudwatch-alarms

### DIFF
--- a/dynamodb_create_cloudwatch_alarms/constants.py
+++ b/dynamodb_create_cloudwatch_alarms/constants.py
@@ -1,1 +1,1 @@
-VERSION = '2.1'
+VERSION = '2.2'

--- a/dynamodb_create_cloudwatch_alarms/main.py
+++ b/dynamodb_create_cloudwatch_alarms/main.py
@@ -119,9 +119,9 @@ def get_ddb_alarms_to_create(ddb_tables, aws_cw_connect, sns_topic_arn):
                 name=u'{}-{}-BasicAlarm'.format(
                     table, metric),
                 namespace=u'AWS/DynamoDB',
-                metric=u'{}'.format(metric), statistic='Sum',
+                metric=u'{}'.format(metric), statistic='Average',
                 comparison=u'>=',
-                threshold=0,
+                threshold=1,
                 period=ALARM_PERIOD,
                 evaluation_periods=ALARM_EVALUATION_PERIOD,
                 # Below insert the actions appropriate.


### PR DESCRIPTION
https://app.asana.com/0/20810103798902/196795696869962

Moved the Metric to Average.
Also, I have increased the threshold to 1, as i think it is not useful to have an alarm if an average was e.g 0.5, as this means only one datapoint can cause noise. LMK if we need to make this higher.
